### PR TITLE
Correções

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -19,13 +19,11 @@ sentry-sdk = "*"
 django-debug-toolbar = "*"
 django = "*"
 django-ordered-model = "*"
-reverse = "*"
 
 [dev-packages]
 flake8 = "*"
 pytest-cov = "*"
 codecov = "*"
-model-mommy = "*"
 model-bakery = "*"
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e5cdef5f66db9169433334c2c418d46589c63f048578e8bf9a7d67e0e269d0f0"
+            "sha256": "111f1e10ce70fb1a3cd43834009d77737c39241d3fb2edf10c1c45730a819b39"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -24,14 +24,6 @@
             "markers": "python_version >= '3.7'",
             "version": "==3.5.0"
         },
-        "atomicwrites": {
-            "hashes": [
-                "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197",
-                "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"
-            ],
-            "markers": "sys_platform == 'win32'",
-            "version": "==1.4.0"
-        },
         "attrs": {
             "hashes": [
                 "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4",
@@ -42,19 +34,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:b1c90fcdce73e6bc11f6a7a834b89e365257ddd12d8e27e0c2871184d4ceb740",
-                "sha256:c82456100f503f405a7690f9aba1b32182f602b5afec06458522a3d682ab6ca6"
+                "sha256:8c7c296edac2a76d3fdc9e9664d2adac37ac0205b18ffda22e3f1e3c078038ba",
+                "sha256:c971850fa4466ed7ebcd9bbef58d03cd81c9dd3cf4e45cc1a916fc44cf2dcaf8"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.21.20"
+            "version": "==1.21.24"
         },
         "botocore": {
             "hashes": [
-                "sha256:d913c2670799dece00ccd4880e164f8c05df8cfadd7d3fe02e01fe384ad0f8c1",
-                "sha256:e7b06f6bb88593b8d668ee50cf7c42b85f3db1cbfef7eb7b939b17ba1e3ce73f"
+                "sha256:6f8c79a784f04f074319cfbc4de7f858639049ac73065b26fd97b66839ab3b30",
+                "sha256:e6b5fe8bf1d3515256ebeea67b9e89d2f0cacf19131c1c86d744e5037f627d6e"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.24.20"
+            "version": "==1.24.24"
         },
         "certifi": {
             "hashes": [
@@ -87,14 +79,6 @@
             ],
             "index": "pypi",
             "version": "==2.2.0"
-        },
-        "colorama": {
-            "hashes": [
-                "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b",
-                "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"
-            ],
-            "markers": "sys_platform == 'win32'",
-            "version": "==0.4.4"
         },
         "coverage": {
             "extras": [
@@ -218,11 +202,11 @@
         },
         "jmespath": {
             "hashes": [
-                "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9",
-                "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"
+                "sha256:a490e280edd1f57d6de88636992d05b71e97d69a26a19f058ecf7d304474bf5e",
+                "sha256:e8dcd576ed616f14ec02eed0005c85973b5890083313860136657e24784e4c04"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.10.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==1.0.0"
         },
         "packaging": {
             "hashes": [
@@ -320,11 +304,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:b555252a95bbb2a37a97b5ac2eb050c436f7989993565f5e0c9128fcaacadd0e",
-                "sha256:f1089d218cfcc63a212c42896f1b7fbf096874d045e1988186861a1a87d27b47"
+                "sha256:841132caef6b1ad17a9afde46dc4f6cfa59a05f9555aae5151f73bdf2820ca63",
+                "sha256:92f723789a8fdd7180b6b06483874feca4c48a5c76968e03bb3e7f806a1869ea"
             ],
             "index": "pypi",
-            "version": "==7.1.0"
+            "version": "==7.1.1"
         },
         "pytest-cov": {
             "hashes": [
@@ -366,13 +350,6 @@
             "index": "pypi",
             "version": "==2.27.1"
         },
-        "reverse": {
-            "hashes": [
-                "sha256:5dffd7d38ab9f580ea3e5a744498341e37caea71990c93283e622142be54b049"
-            ],
-            "index": "pypi",
-            "version": "==0.1.0"
-        },
         "s3transfer": {
             "hashes": [
                 "sha256:7a6f4c4d1fdb9a2b640244008e142cbc2cd3ae34b386584ef044dd0f27101971",
@@ -383,19 +360,19 @@
         },
         "sentry-sdk": {
             "hashes": [
-                "sha256:411a8495bd18cf13038e5749e4710beb4efa53da6351f67b4c2f307c2d9b6d49",
-                "sha256:aa52da941c56b5a76fd838f8e9e92a850bf893a9eb1e33ffce6c21431d07ee30"
+                "sha256:32af1a57954576709242beb8c373b3dbde346ac6bd616921def29d68846fb8c3",
+                "sha256:38fd16a92b5ef94203db3ece10e03bdaa291481dd7e00e77a148aa0302267d47"
             ],
             "index": "pypi",
-            "version": "==1.5.7"
+            "version": "==1.5.8"
         },
         "setuptools": {
             "hashes": [
-                "sha256:2347b2b432c891a863acadca2da9ac101eae6169b1d3dfee2ec605ecd50dbfe5",
-                "sha256:e4f30b9f84e5ab3decf945113119649fec09c1fc3507c6ebffec75646c56e62b"
+                "sha256:6599055eeb23bfef457d5605d33a4d68804266e6cb430b0fb12417c5efeae36c",
+                "sha256:782ef48d58982ddb49920c11a0c5c9c0b02e7d7d1c2ad0aa44e1a1e133051c96"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==60.9.3"
+            "version": "==60.10.0"
         },
         "six": {
             "hashes": [
@@ -429,14 +406,6 @@
             "markers": "python_version >= '3.6'",
             "version": "==4.1.1"
         },
-        "tzdata": {
-            "hashes": [
-                "sha256:3eee491e22ebfe1e5cfcc97a4137cd70f092ce59144d81f8924a844de05ba8f5",
-                "sha256:68dbe41afd01b867894bbdfd54fa03f468cfa4f0086bfb4adcd8de8f24f3ee21"
-            ],
-            "markers": "sys_platform == 'win32'",
-            "version": "==2021.5"
-        },
         "urllib3": {
             "hashes": [
                 "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14",
@@ -454,14 +423,6 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==3.5.0"
-        },
-        "atomicwrites": {
-            "hashes": [
-                "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197",
-                "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"
-            ],
-            "markers": "sys_platform == 'win32'",
-            "version": "==1.4.0"
         },
         "attrs": {
             "hashes": [
@@ -494,14 +455,6 @@
             ],
             "index": "pypi",
             "version": "==2.1.12"
-        },
-        "colorama": {
-            "hashes": [
-                "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b",
-                "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"
-            ],
-            "markers": "sys_platform == 'win32'",
-            "version": "==0.4.4"
         },
         "coverage": {
             "extras": [
@@ -599,14 +552,6 @@
             "index": "pypi",
             "version": "==1.4.0"
         },
-        "model-mommy": {
-            "hashes": [
-                "sha256:3d332afce941c57f1990f45b083ba13252ba74fcd1ae43fd047e5af7a70fb312",
-                "sha256:40d6e740aad7509e696a324b94cf2b0a104da93c3d4a7924cea1be3d0eb95b4f"
-            ],
-            "index": "pypi",
-            "version": "==2.0.0"
-        },
         "packaging": {
             "hashes": [
                 "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
@@ -657,11 +602,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:b555252a95bbb2a37a97b5ac2eb050c436f7989993565f5e0c9128fcaacadd0e",
-                "sha256:f1089d218cfcc63a212c42896f1b7fbf096874d045e1988186861a1a87d27b47"
+                "sha256:841132caef6b1ad17a9afde46dc4f6cfa59a05f9555aae5151f73bdf2820ca63",
+                "sha256:92f723789a8fdd7180b6b06483874feca4c48a5c76968e03bb3e7f806a1869ea"
             ],
             "index": "pypi",
-            "version": "==7.1.0"
+            "version": "==7.1.1"
         },
         "pytest-cov": {
             "hashes": [
@@ -694,14 +639,6 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==2.0.1"
-        },
-        "tzdata": {
-            "hashes": [
-                "sha256:3eee491e22ebfe1e5cfcc97a4137cd70f092ce59144d81f8924a844de05ba8f5",
-                "sha256:68dbe41afd01b867894bbdfd54fa03f468cfa4f0086bfb4adcd8de8f24f3ee21"
-            ],
-            "markers": "sys_platform == 'win32'",
-            "version": "==2021.5"
         },
         "urllib3": {
             "hashes": [

--- a/pypro/aperitivos/tests/test_indice.py
+++ b/pypro/aperitivos/tests/test_indice.py
@@ -1,13 +1,14 @@
 import pytest
 from django.urls import reverse
+from model_bakery import baker
+
 from pypro.aperitivos.models import Video
 from pypro.django_assertions import assert_contains
-from model_mommy import mommy
 
 
 @pytest.fixture
 def videos(db):
-    return mommy.make(Video, 3)
+    return baker.make(Video, 3)
 
 
 @pytest.fixture

--- a/pypro/aperitivos/tests/test_video.py
+++ b/pypro/aperitivos/tests/test_video.py
@@ -1,6 +1,6 @@
 import pytest
 from django.urls import reverse
-from model_mommy import mommy
+from model_bakery import baker
 
 from pypro.aperitivos.models import Video
 from pypro.django_assertions import assert_contains
@@ -8,7 +8,7 @@ from pypro.django_assertions import assert_contains
 
 @pytest.fixture
 def video(db):
-    return mommy.make(Video)
+    return baker.make(Video)
 
 
 @pytest.fixture

--- a/pypro/modulos/models.py
+++ b/pypro/modulos/models.py
@@ -12,10 +12,6 @@ class Modulo(OrderedModel):
     class Meta(OrderedModel.Meta):
         pass
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(args, kwargs)
-        self.aula_set = None
-
     def __str__(self):
         return self.titulo
 

--- a/pypro/modulos/tests/test_aba_de_modulos.py
+++ b/pypro/modulos/tests/test_aba_de_modulos.py
@@ -1,14 +1,15 @@
 import pytest
 from django.urls import reverse
+from model_bakery import baker
+
 from pypro.django_assertions import assert_contains
-from model_mommy import mommy
 
 from pypro.modulos.models import Modulo
 
 
 @pytest.fixture
 def modulos(db):
-    return mommy.make(Modulo, 2)
+    return baker.make(Modulo, 2)
 
 
 @pytest.fixture

--- a/pypro/modulos/tests/test_aula_detalhe.py
+++ b/pypro/modulos/tests/test_aula_detalhe.py
@@ -1,18 +1,20 @@
 import pytest
 from django.urls import reverse
+from model_bakery import baker
+
 from pypro.django_assertions import assert_contains
-from model_mommy import mommy
+
 from pypro.modulos.models import Modulo, Aula
 
 
 @pytest.fixture
 def modulo(db):
-    return mommy.make(Modulo)
+    return baker.make(Modulo)
 
 
 @pytest.fixture
 def aula(modulo):
-    return mommy.make(Aula, modulo=modulo)
+    return baker.make(Aula, modulo=modulo)
 
 
 @pytest.fixture

--- a/pypro/modulos/tests/test_facade.py
+++ b/pypro/modulos/tests/test_facade.py
@@ -1,12 +1,14 @@
 import pytest
+from model_bakery import baker
+
 from pypro.modulos import facade
-from model_mommy import mommy
+
 from pypro.modulos.models import Modulo
 
 
 @pytest.fixture
 def modulos(db):
-    return [mommy.make(Modulo, titulo=s) for s in 'Antes Depois'.split()]
+    return [baker.make(Modulo, titulo=s) for s in 'Antes Depois'.split()]
 
 
 def test_listar_modulos_ordenados(modulos):

--- a/pypro/modulos/tests/test_modulo_detalhe.py
+++ b/pypro/modulos/tests/test_modulo_detalhe.py
@@ -1,19 +1,21 @@
 import pytest
 from django.urls import reverse
+from model_bakery import baker
+
 from pypro.django_assertions import assert_contains
-from model_mommy import mommy
+
 from pypro.modulos.models import Modulo
 from pypro.modulos.models import Aula
 
 
 @pytest.fixture
 def modulo(db):
-    return mommy.make(Modulo)
+    return baker.make(Modulo)
 
 
 @pytest.fixture
 def aulas(modulo):
-    return mommy.make(Aula, 3, modulo=modulo)
+    return baker.make(Aula, 3, modulo=modulo)
 
 
 @pytest.fixture

--- a/pypro/modulos/urls.py
+++ b/pypro/modulos/urls.py
@@ -4,5 +4,5 @@ from pypro.modulos import views
 app_name = 'modulos'
 urlpatterns = [
     path('<slug:slug>', views.detalhe, name='detalhe'),
-    path('/aulas/<slug:slug>', views.aula, name='detalhe'),
+    path('/aulas/<slug:slug>', views.aula, name='aula'),
 ]


### PR DESCRIPTION
- removido libs `model-mommy` e `reverse` por não serem usadas:
`pipenv uninstall model-mommy reverse`
- alterado `mommy` para `bakery`
- removido `__init__` em `models` de módulos.
- **PROBLEMA**: corrigido rota de módulos.